### PR TITLE
Quotes in dependencies are deprecated

### DIFF
--- a/modules/google/apis/initial-config-apis/main.tf
+++ b/modules/google/apis/initial-config-apis/main.tf
@@ -16,7 +16,7 @@ resource "google_project_service" "project_compute" {
   disable_on_destroy = true
   disable_dependent_services = true
 
-  depends_on = ["google_project_service.project_cloud"]
+  depends_on = [google_project_service.project_cloud]
 }
 
 resource "google_project_service" "project_iam" {
@@ -25,7 +25,7 @@ resource "google_project_service" "project_iam" {
   disable_on_destroy = true
   disable_dependent_services = true
 
-  depends_on = ["google_project_service.project_cloud"]
+  depends_on = [google_project_service.project_cloud]
 }
 
 resource "google_project_service" "project_app_engine" {
@@ -34,7 +34,7 @@ resource "google_project_service" "project_app_engine" {
   disable_on_destroy = true
   disable_dependent_services = true
 
-  depends_on = ["google_project_service.project_cloud"]
+  depends_on = [google_project_service.project_cloud]
 }
 
 resource "google_project_service" "project_app_kms" {
@@ -43,5 +43,5 @@ resource "google_project_service" "project_app_kms" {
   disable_on_destroy = true
   disable_dependent_services = true
 
-  depends_on = ["google_project_service.project_cloud"]
+  depends_on = [google_project_service.project_cloud]
 }

--- a/modules/google/app-engine/main.tf
+++ b/modules/google/app-engine/main.tf
@@ -23,7 +23,7 @@ resource "google_app_engine_standard_app_version" "initial_version" {
       source_url = "https://storage.googleapis.com/${google_storage_bucket.standard_app_bucket.name}/${google_storage_bucket_object.standard_app_bucket_object.name}"
     }
   }
-  depends_on = ["google_app_engine_application.app_engine_application"]
+  depends_on = [google_app_engine_application.app_engine_application]
 }
 
 resource "google_storage_bucket" "standard_app_bucket" {


### PR DESCRIPTION
Terraform will be mark deprecated the quotes on the dependencies, now is a warning but in the future will be an error.